### PR TITLE
Add option to hide Bluetooth Icon when disconnected in Status Bar (2/2)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -6272,6 +6272,10 @@
     <string name="volbtn_music_controls_summary">When screen off, long-pressing the volume rockers will seek music tracks</string>
     <string name="volume_button_toggle_info">Volume rocker wake must be disabled</string>
 
+    <!-- Show bluetooth icon when disconnected -->
+    <string name="status_bar_bluetooth_icon">Show Bluetooth icon</string>
+    <string name="status_bar_bluetooth_icon_summary">Display the bluetooth icon when it is enabled but not connected</string>
+
     <!-- Show notification count -->
     <string name="status_bar_notif_count_title">Show notification count</string>
     <string name="status_bar_notif_count_summary">Display the number of pending notifications</string>

--- a/res/xml/status_bar_settings.xml
+++ b/res/xml/status_bar_settings.xml
@@ -14,6 +14,12 @@
         android:key="clock_style_pref"
         android:title="@string/status_bar_clock"
 	android:summary="@string/status_bar_clock_summary" />
+	
+	 <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
+        android:key="show_bluetooth_icon"
+        android:title="@string/status_bar_bluetooth_icon"
+        android:summary="@string/status_bar_bluetooth_icon_summary"
+        android:defaultValue="true" />
 
     <PreferenceScreen
 	android:key="network_traffic_state"


### PR DESCRIPTION
Add an option to hide the bluetooth icon from the status bar when it is enabled, but disconnected / not connected. The icon will still be shown when it is connected. This behavior will be similar to the wifi icon (hidden when wifi is on but not connected). Useful when you have bluetooth open all the time, but you don't want to see the icon unless connected.

Credits to mnm9994u and MrBaNkS for "Add option to hide AlarmClock Icon in StatusBar [1/2]" https://github.com/SimpleAOSP-Lollipop/platform_frameworks_base/commit/5ef3106a669bf765e1d34628d912df624b07dc1f
